### PR TITLE
Reminder notification

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -66,3 +66,9 @@ services:
   redis:
     image: redis:alpine
     restart: always
+
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: always
+    ports:
+        - "8125:8025"

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -23,6 +23,10 @@ RUN if [ ! -f .env ]; then \
     sed -i 's/REDIS_HOST=.*/REDIS_HOST=redis/' .env; \
     sed -i 's/REDIS_PASSWORD=.*/REDIS_PASSWORD=null/' .env; \
     sed -i 's/REDIS_PORT=.*/REDIS_PORT=6379/' .env; \
+    sed -i 's/MAIL_HOST=.*/MAIL_HOST=mailpit/' .env; \
+    sed -i 's/MAIL_PORT=.*/MAIL_PORT=1025/' .env; \
+    sed -i 's/MAIL_FROM_ADDRESS=.*/MAIL_FROM_ADDRESS=remindme@mail.com/' .env; \
+    sed -i 's/MAIL_FROM_NAME=.*/MAIL_FROM_NAME=RemindMe/' .env; \
 fi
 
 RUN composer install

--- a/src/app/Console/Commands/SendReminder.php
+++ b/src/app/Console/Commands/SendReminder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SendReminder as JobsSendReminder;
+use App\Models\Reminder;
+use Illuminate\Console\Command;
+
+class SendReminder extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:send-reminder';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send due reminders';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $reminders = Reminder::query()
+            ->with('user')
+            ->whereNull('sent_at')
+            ->where('remind_at', '<=', time())
+            ->get();
+
+        foreach ($reminders as $reminder) {
+            JobsSendReminder::dispatch($reminder);
+        }
+    }
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\SendReminder;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -12,7 +13,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command(SendReminder::class)->everyMinute();
     }
 
     /**

--- a/src/app/Jobs/SendReminder.php
+++ b/src/app/Jobs/SendReminder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Reminder;
+use App\Notifications\Reminder as NotificationsReminder;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SendReminder implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(private Reminder $reminder)
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->reminder->user->notify(new NotificationsReminder($this->reminder));
+
+        $this->reminder->update([
+            'sent_at' => time(),
+        ]);
+    }
+
+    public function uniqueId(): string
+    {
+        return $this->reminder->id;
+    }
+}

--- a/src/app/Models/Reminder.php
+++ b/src/app/Models/Reminder.php
@@ -15,6 +15,7 @@ class Reminder extends Model
         'description',
         'remind_at',
         'event_at',
+        'sent_at',
     ];
 
     protected $casts = [

--- a/src/app/Notifications/Reminder.php
+++ b/src/app/Notifications/Reminder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Reminder as ModelsReminder;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class Reminder extends Notification
+{
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(private ModelsReminder $reminder)
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject("Reminder: Upcoming Event - {$this->reminder->title}")
+            ->markdown('mail.reminder', ['reminder' => $this->reminder]);
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/database/factories/ReminderFactory.php
+++ b/src/database/factories/ReminderFactory.php
@@ -21,7 +21,7 @@ class ReminderFactory extends Factory
 
         return [
             'user_id' => User::factory(),
-            'title' => fake()->title(),
+            'title' => fake()->sentence(2),
             'description' => fake()->text(),
             'remind_at' => fake()->dateTimeBetween('+1 hour', $eventAt)->getTimestamp(),
             'event_at' => $eventAt->getTimestamp(),

--- a/src/resources/views/mail/reminder.blade.php
+++ b/src/resources/views/mail/reminder.blade.php
@@ -1,0 +1,23 @@
+@inject('carbon', 'Carbon\Carbon')
+
+<x-mail::layout>
+<x-slot:header>
+<tr>
+<td class="header">
+<h1 style="text-align: center;">RemindMe</h1>
+</td>
+</tr>
+</x-slot:header>
+
+This is a friendly reminder about the upcoming event in your schedule.
+
+**Event Name**: {{ $reminder->title }}  
+**Date and Time**: {{ $carbon::parse($reminder->event_at)->format('F j, Y, g:i a') }}  
+**Description**: {{ $reminder->description }}  
+
+<x-slot:footer>
+<tr>
+<td class="header" />
+</tr>
+</x-slot:footer>
+</x-mail::layout>


### PR DESCRIPTION
Reminder notification workflow
- Task Scheduling will call the `SendReminder` command every minute
- `SendReminder` command will retrieve reminder data that is due and notifications have not yet been sent
- `SendReminder` job will be dispatched
- `SendReminder` job will call `Reminder` notification to send email

To ensure notifications do not overlap, the `SendReminder` job is used which implements the `ShouldBeUnique` interface, the notification feature in Laravel does not support `ShouldBeUnique`

For development needs, docker Mailpit has been added and the web UI is exposed on port `8125`